### PR TITLE
TASK-1712 post-message-manager send 함수 대신 notify 사용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@concord-consortium/lara-interactive-api": "^1.9.4",
         "@concord-consortium/token-service": "^2.1.0",
         "@rails/activestorage": "^7.2.201",
-        "@team-monolith/post-message-manager": "^1.0.3",
+        "@team-monolith/post-message-manager": "^1.1.0",
         "@types/rails__activestorage": "^7.1.1",
         "aws-sdk": "^2.1526.0",
         "base64-js": "^1.5.1",
@@ -1734,9 +1734,9 @@
       }
     },
     "node_modules/@team-monolith/post-message-manager": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@team-monolith/post-message-manager/-/post-message-manager-1.0.3.tgz",
-      "integrity": "sha512-lhmxV+JEnUJUPlvlOH+V45ocz8grNMltqGCgo/xMeN8IWKJqJ2b4feY7HKzCoaM0Ybx0WlRNtexCGiYLG3sM2A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@team-monolith/post-message-manager/-/post-message-manager-1.1.0.tgz",
+      "integrity": "sha512-gyWCt5/CsFex2euGhfkIigwiuJ/ZXZ4a0z3kx4NwL+0aj9hOmDD6PbcZ2tDAAZHGbXd3ZY18ONeUhBuet3wFGQ==",
       "dependencies": {
         "uid": "^2.0.2"
       }
@@ -15430,9 +15430,9 @@
       }
     },
     "@team-monolith/post-message-manager": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@team-monolith/post-message-manager/-/post-message-manager-1.0.3.tgz",
-      "integrity": "sha512-lhmxV+JEnUJUPlvlOH+V45ocz8grNMltqGCgo/xMeN8IWKJqJ2b4feY7HKzCoaM0Ybx0WlRNtexCGiYLG3sM2A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@team-monolith/post-message-manager/-/post-message-manager-1.1.0.tgz",
+      "integrity": "sha512-gyWCt5/CsFex2euGhfkIigwiuJ/ZXZ4a0z3kx4NwL+0aj9hOmDD6PbcZ2tDAAZHGbXd3ZY18ONeUhBuet3wFGQ==",
       "requires": {
         "uid": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@concord-consortium/lara-interactive-api": "^1.9.4",
     "@concord-consortium/token-service": "^2.1.0",
     "@rails/activestorage": "^7.2.201",
-    "@team-monolith/post-message-manager": "^1.0.3",
+    "@team-monolith/post-message-manager": "^1.1.0",
     "@types/rails__activestorage": "^7.1.1",
     "aws-sdk": "^2.1526.0",
     "base64-js": "^1.5.1",

--- a/src/code/post-message-manager.ts
+++ b/src/code/post-message-manager.ts
@@ -44,14 +44,10 @@ export function postiframeLoadedMessageToParent() {
     "iframe_key"
   )
   if (!iframeKey) return
-  try {
-    postMessageManager.send({
-      messageType: `iframeLoaded-${iframeKey}`,
-      payload: null,
-      target: window.parent,
-      targetOrigin: "*",
-    })
-  } catch {
-    /* ignore */
-  }
+  postMessageManager.notify({
+    messageType: `iframeLoaded-${iframeKey}`,
+    payload: null,
+    target: window.parent,
+    targetOrigin: "*",
+  })
 }


### PR DESCRIPTION
post-message-manager send 함수 대신 notify 사용하여 코드를 리팩토링 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **의존성 업데이트**
	- `@team-monolith/post-message-manager` 패키지를 버전 `^1.0.3`에서 `^1.1.0`으로 업그레이드

- **코드 변경**
	- 메시지 전송 방식을 `send` 메서드에서 `notify` 메서드로 변경
	- 오류 처리 로직 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->