### PR TITLE
[TASK-5726] feat: CODAP 바이너리 외부 업로드용 uploadBinary API 추가

### DIFF
--- a/src/code/client.ts
+++ b/src/code/client.ts
@@ -44,6 +44,7 @@ import {
   registerReloadPostMessage,
   registerSavePostMessage,
 } from "./post-message-manager"
+import { createBlobAndUrlFromFile } from "./api/directUploads"
 import getHashParam from './utils/get-hash-param'
 
 let CLOUDFILEMANAGER_EVENT_ID = 0
@@ -1192,6 +1193,15 @@ class CloudFileManagerClient {
         return this.saveSecondaryFile(stringContent, metadata, callback)
       })
     }
+  }
+
+  // AIDEV-NOTE:
+  // 큰 바이너리(이미지 등)를 CODAP 문서에 inline base64로 임베드하지 않고 외부 서버에 업로드한 뒤
+  // URL만 문서에 저장하기 위한 공개 API. CODAP가 `DG.cfmClient.uploadBinary(file)` 형태로 호출한다.
+  // 내부적으로 기존 ActiveStorage DirectUpload 경로를 그대로 사용한다.
+  async uploadBinary(file: File): Promise<string> {
+    const { url } = await createBlobAndUrlFromFile(file)
+    return url
   }
 
   // Saves a file to backend, but does not update current metadata.


### PR DESCRIPTION
## 배경

CODAP 문서 저장(save)은 iframe postMessage RPC로 동작하며 5초 타임아웃이 걸려 있다. 사용자가 그래프 배경 이미지나 IMAGE 파일을 import하면, 해당 이미지가 **base64 data URL로 문서에 inline 임베드**된다. 이미지가 크면 문서 직렬화(`toArchive()`)와 업로드가 함께 비대해져 5초 타임아웃을 초과하고, 실제로는 저장이 성공해도 프론트에 "저장 오류" 모달이 뜬다.

관련 작업: TASK-5726 (무안행복중학교 교사 수행평가 저장 오류 긴급 제보 건)

근본 해결책은 이미지를 inline base64로 임베드하지 않고 **외부 파일 서버(Rails ActiveStorage DirectUpload)에 업로드한 뒤 URL만 문서에 저장**하는 것이다. 이 PR은 그 중 CODAP이 호출할 CFM 측 공개 API를 제공한다.

## 변경사항

- `CloudFileManagerClient`에 `uploadBinary(file: File): Promise<string>` 공개 메서드 추가 (`src/code/client.ts`)
  - 기존 `createBlobAndUrlFromFile`(`src/code/api/directUploads.ts`)을 래핑하여 signed URL 문자열만 반환한다.
  - CODAP은 `DG.cfmClient.uploadBinary(file)` 형태로 직접 호출한다 (CFM↔CODAP은 동일 origin iframe 참조라 postMessage round-trip 불필요).

## 대안 분석

- **CODAP에서 DirectUpload 직접 구현**: 인증(쿠키 토큰)·의존성이 중복되고 CFM이 진실의 근원이라는 구조가 깨짐 → 기각
- **`createBlobAndUrlFromFile`을 그대로 client에 노출**: ActiveStorage Blob 객체까지 외부로 새어나가 API surface가 넓어짐 → URL만 반환하는 thin wrapper 채택
- **postMessage `uploadBinary` 메시지 신설**: 동일 origin에서 client 직접 참조가 가능한데 불필요한 메시지 채널 추가 → 기각

## 검증

- `npx tsc --noEmit` 통과 (변경 파일 `client.ts` 에러 없음)
- CODAP 레포에서 `npm run build:codap`로 번들 빌드 성공, 실제 import→save 동작 확인

## 참고

이 PR과 짝을 이루는 CODAP 측 변경(import 경로를 `uploadBinary` 사용으로 전환)은 team-monolith-product/codap 레포의 `feature/direct-upload` 브랜치 PR에서 진행한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)